### PR TITLE
Add repository entry for Apache Shiro

### DIFF
--- a/oss-repository-tier/external_repositories.txtpb
+++ b/oss-repository-tier/external_repositories.txtpb
@@ -364,3 +364,9 @@ repository {
   product_vuln_scope: SCOPE_OSS_VRP
 }
 
+repository {
+  url:  "https://github.com"/apache/shiro
+  tier:TIER_1
+  product_vuln_scope:SCOPE_OSS_VRP
+ }
+


### PR DESCRIPTION
Closes #58
This PR adds Apache Shiro into the Tier 1 list under external_repositories.txtpb as requested.