### PR TITLE
Update external_domains_google.asciipb

### DIFF
--- a/domain-tiers/external_domains_google.asciipb
+++ b/domain-tiers/external_domains_google.asciipb
@@ -2141,10 +2141,6 @@ domain: {
   tier: TIER4
 }
 domain: {
-  fqdn: "sketchup.com"
-  tier: TIER4
-}
-domain: {
   fqdn: "skybox.com"
   tier: TIER4
 }


### PR DESCRIPTION
Closes #55
Removed sketchup.com from the external domains list since it was sold by Google in 2012.